### PR TITLE
自动挂最后一日的号码 & 指定配置文件地址

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-config.json
+*.json
+!_config.json
+
 *.cookies
 *.pyc

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ https://bjguahao.0x7c00.cn/
 
 - Python
 
+## 运行
+
+- 默认用法： ```python2 bjguahao.py```
+- 指定配置： ```python2 bjguahao.py -c test.json```
+
 ## 配置文件
 
 在脚本目录将 `_config.josn` 重命名为 `config.json`, 然后写入如下数据：
@@ -27,8 +32,8 @@ https://bjguahao.0x7c00.cn/
     {
         "username":"185xxxxxxx",
         "password":"*******",
-        "date":"2017-02-17",            # 挂号日期
-        "hospitalId":"142",             # 142 北医三院
+        "date":"2017-02-17",            # 挂号日期，当 date='latest' 时，自动挂最新一日
+        "hospitalId":"142",             # 142 北医三院
         "departmentId":"200039602",     # 运动医学科
         "dutyCode":"1",                 # 1:上午  2:下午
         "patientName":"张三",           # 就诊人姓名,可不填,适配多就诊人情况

--- a/bjguahao.py
+++ b/bjguahao.py
@@ -117,6 +117,9 @@ class Guahao(object):
         department_id = self.config.department_id
         duty_code = self.config.duty_code
         duty_date = self.config.date
+	
+	# log current date
+        Log.debug("当前挂号日期: " + self.config.date)
 
         preload = {
             'hospitalId':hospital_id ,
@@ -237,13 +240,20 @@ class Guahao(object):
         appoint_day = m.group('appointDay')
 
         today = datetime.date.today()
+	
+	# 优先确认最新可挂号日期
+        self.stop_date = today + datetime.timedelta(days=int(appoint_day))
+        Log.info("今日可挂号到: " + self.stop_date.strftime("%Y-%m-%d"))
+	
+	# 自动挂最新一天的号
+        if self.config.date == 'latest':
+            self.config.date = unicode(self.stop_date.strftime("%Y-%m-%d"))
+            Log.info("当前挂号日期变更为: " + self.config.date)
 
+        # 生成放号时间和程序开始时间
         con_data_str = self.config.date + " " + refresh_time + ":00"
         self.start_time =  datetime.datetime.strptime(con_data_str, '%Y-%m-%d %H:%M:%S') +  datetime.timedelta(days= - int(appoint_day))
-        self.stop_date = today + datetime.timedelta(days=int(appoint_day))
-
         Log.info("放号时间: " + self.start_time.strftime("%Y-%m-%d %H:%M"))
-        Log.info("今日可挂号到: " + self.stop_date.strftime("%Y-%m-%d"))
 
     def get_sms_verify_code(self):
         """获取短信验证码"""

--- a/bjguahao.py
+++ b/bjguahao.py
@@ -34,13 +34,13 @@ class Config(object):
         self.patient_name = ""
         self.patient_id = ""
 
-    def load_conf(self):
+    def load_conf(self, config_path):
         """
         加载配置
         """
 
         try:
-            with open('config.json') as json_file:
+            with open(config_path) as json_file:
                 data = json.load(json_file)
                 data = data[0]
                 self.mobile_no = data["username"]
@@ -269,11 +269,11 @@ class Guahao(object):
             Log.error(data["msg"])
             return None
 
-    def run(self):
+    def run(self, config_path):
         """主逻辑"""
 
         config = Config()                       # config对象
-        config.load_conf()                      # 加载配置
+        config.load_conf(config_path)                      # 加载配置
         self.config = config
         self.get_duty_time()
 
@@ -308,6 +308,13 @@ class Guahao(object):
                     break                                    # 挂号成功
 
 if __name__ == "__main__":
-    Log.load_config()
+    # 生成默认 config 地址
+    config_path = 'config.json'
+
+    # 覆盖 config 地址
+    for i in range(1, len(sys.argv)):
+        if (sys.argv[i] == '-c') & (i+1 < len(sys.argv)):
+            config_path = sys.argv[i+1]
+    Log.load_config(config_path)
     guahao = Guahao()
-    guahao.run()
+    guahao.run(config_path)

--- a/log.py
+++ b/log.py
@@ -24,7 +24,7 @@ class Log(object):
     """
 
     @staticmethod
-    def load_config():
+    def load_config(config_path):
         """获取log配置"""
         global debug_level
         global filesystemencoding
@@ -32,7 +32,7 @@ class Log(object):
         filesystemencoding = sys.getfilesystemencoding()
 
         try:
-            with open('config.json') as json_file:
+            with open(config_path) as json_file:
                 data = json.load(json_file)
                 data = data[0]
                 if data["DebugLevel"] == "info":


### PR DESCRIPTION
我自己用了一下没碰到问题；但非编程职业者，无法保证无Bug，故请仔细审核。
测试的话，可以用这个源：https://github.com/coeusite/bjguahao/

实现功能：
- 当 date='latest' 时，自动将最新可挂号日期（self.stop_date）设定为挂号日期（self.config.date）
- 使用"-c"参数指定配置文件地址，例如 python2 bjguahao.py -c test.json 

BTW 某些号真难挂啊，30s内就没了（感谢脚本帮我抢到一个）。