### PR TITLE
获取病人id的逻辑位置改变为选择医生之后马上获取病人ID

### DIFF
--- a/bjguahao.py
+++ b/bjguahao.py
@@ -291,6 +291,7 @@ class Guahao(object):
         doctor = "";
         while True:
             doctor = self.select_doctor()            # 2. 选择医生
+	    self.get_patient_id(doctor)         # 3. 获取病人id
             if doctor == "NoDuty":
                 Log.error("没号了,  亲~")
                 break
@@ -302,7 +303,6 @@ class Guahao(object):
                 if sms_code == None:
                     time.sleep(1)
 
-                self.get_patient_id(doctor)         # 3. 获取病人id
                 result = self.get_it(doctor, sms_code)                 # 4.挂号
                 if result == True:
                     break                                    # 挂号成功


### PR DESCRIPTION
获取病人id的逻辑位置改变到了选择医生之后马上进行病人ID获取（页面逻辑上似乎也是这样的，点击医生，选择就诊人，之后获取验证码），避免造成最后提交时请求头中的referer错误返回非json数据导致挂号失败的问题。