### PR TITLE
Android QPython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-*.json
-!_config.json
-
 *.cookies
 *.pyc
 .idea/
-.config.yaml
+*.yaml
+
+!config.yaml

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Copyright (C) 2017
 
-https://bjguahao.0x7c00.cn/
-
 **目前稳定版已经发布，欢迎吐槽和试用**
 
 * 本程序用于 [北京市预约挂号统一平台](http://www.bjguahao.gov.cn/) 的挂号，只支持北京地区医院的挂号。
@@ -78,6 +76,9 @@ DebugLevel: "info"
 
 #使用ios短信和mac电脑接收验证码
 useIMessage: "false"
+
+# 是否使用 QPython3 运行本脚本
+useQPython3: "false"
 ```
 
 ## 文档

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Copyright (C) 2017
 6. 将整个项目复制到你的 Android
 7. 在 QPython3 中运行```qpython3_run.py```
 
-若配置文件不在项目目录，也可修改```qpython3_run.py```中的```config_path```为配置文件的**绝对**地址，如
-```
-config_path = "/storage/emulated/0/qpython/projects3/bjguahao/custom.yaml"
-```
+*备注：*
+- 若配置文件不在项目目录，也可修改```qpython3_run.py```中的```config_path```为配置文件的**绝对**地址
+- 如需以项目的形式直接运行脚本，可以将```qpython3_run.py```改名为```main.py```，并将文件夹放置在```qpython/projects3/```下
+- 也可将文件夹放置在```qpython/scripts3/```下，而后为```qpython3_run.py```建立桌面快捷方式。
 
 ## 配置文件
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ Copyright (C) 2017
     - 默认用法： ```python bjguahao.py```
     - 指定配置： ```python bjguahao.py -c your-conf.yaml```
 
+**Android QPython3 使用方法**
+1. 安装 [QPython3](https://play.google.com/store/apps/details?id=org.qpython.qpy3) 和 [QPython](https://play.google.com/store/apps/details?id=org.qpython.qpy)
+2. 安装 [QPy3.6](https://play.google.com/store/apps/details?id=org.qpython.qpy36) 并运行（会安装 Python 3.6）
+3. 在 QPython3 中将版本切为 Python 3.6（默认为 Python 3.2）
+4. 修改配置文件(```config.yaml```或自定义)
+5. 由于 QPython3 不支持传参，如需指定配置文件，需手动修改```qpython3_run.py```中的```config_name```配置文件名
+6. 将整个项目复制到你的 Android
+7. 在 QPython3 中运行```qpython3_run.py```
+
+若配置文件不在项目目录，也可修改```qpython3_run.py```中的```config_path```为配置文件的**绝对**地址，如
+```
+config_path = "/storage/emulated/0/qpython/projects3/bjguahao/custom.yaml"
+```
+
 ## 配置文件
 
 默认配置文件 `config.yaml`
@@ -77,7 +91,7 @@ DebugLevel: "info"
 #使用ios短信和mac电脑接收验证码
 useIMessage: "false"
 
-# 是否使用 QPython3 运行本脚本
+# 是否使用 QPython3.6 运行本脚本
 useQPython3: "false"
 ```
 

--- a/bjguahao.py
+++ b/bjguahao.py
@@ -11,7 +11,6 @@ import json
 import time
 import datetime
 import logging
-import imessage
 from lib.prettytable import PrettyTable
 
 if sys.version_info.major != 3:
@@ -113,11 +112,15 @@ class Guahao(object):
 
         self.config = Config(config_path)                       # config对象
         if self.config.useIMessage == 'true':
+            # 按需导入 imessage.py
+            import imessage
             self.imessage = imessage.IMessage()
         else:
             self.imessage = None
 
         if self.config.useQPython3 == 'true':
+            # 按需导入 qpython3.py
+            import qpython3
             self.qpython3 = qpython3.QPython3()
         else:
             self.qpython3 = None

--- a/bjguahao.py
+++ b/bjguahao.py
@@ -65,9 +65,15 @@ class Config(object):
                 self.patient_name = data["patientName"]
                 self.doctorName = data["doctorName"]
                 self.patient_id = int()
-                self.useIMessage = data["useIMessage"]
-                self.useQPython3 = data["useQPython3"]
-
+                try:
+                    self.useIMessage = data["useIMessage"]
+                except KeyError:
+                    self.useIMessage = "false"
+                try:
+                    self.useQPython3 = data["useQPython3"]
+                except KeyError:
+                    self.useQPython3 = "false"
+                
                 logging.info("配置加载完成")
                 logging.debug("手机号:" + str(self.mobile_no))
                 logging.debug("挂号日期:" + str(self.date))

--- a/bjguahao.py
+++ b/bjguahao.py
@@ -66,6 +66,7 @@ class Config(object):
                 self.doctorName = data["doctorName"]
                 self.patient_id = int()
                 self.useIMessage = data["useIMessage"]
+                self.useQPython3 = data["useQPython3"]
 
                 logging.info("配置加载完成")
                 logging.debug("手机号:" + str(self.mobile_no))
@@ -76,6 +77,7 @@ class Config(object):
                 logging.debug("就诊人姓名:" + str(self.patient_name))
                 logging.debug("所选医生:" + str(self.doctorName))
                 logging.debug("使用mac电脑接收验证码:" + str(self.useIMessage))
+                logging.debug("是否使用 QPython3 运行本脚本:" + str(self.useQPython3))
 
                 if not self.date:
                     logging.error("请填写挂号时间")
@@ -108,6 +110,11 @@ class Guahao(object):
             self.imessage = imessage.IMessage()
         else:
             self.imessage = None
+
+        if self.config.useQPython3 == 'true':
+            self.qpython3 = qpython3.QPython3()
+        else:
+            self.qpython3 = None
 
     def is_login(self):
 
@@ -338,10 +345,12 @@ class Guahao(object):
         logging.debug(response.text)
         if data["msg"] == "OK." and data["code"] == 200:
             logging.info("获取验证码成功")
-            if self.imessage is None:
-                code = input("输入短信验证码: ")
-            else:
+            if self.imessage is not None: # 如果使用 iMessage
                 code = self.imessage.get_verify_code()
+            elif self.qpython3 is not None: # 如果使用 QPython3
+                code = self.qpython3.get_verify_code()
+            else:
+                code = input("输入短信验证码: ")
             return code
         elif data["msg"] == "短信发送太频繁" and data["code"] == 812:
             logging.error(data["msg"])

--- a/config.yaml
+++ b/config.yaml
@@ -41,5 +41,5 @@ DebugLevel: "info"
 #使用ios短信和mac电脑接收验证码
 useIMessage: "false"
 
-# 是否使用 QPython3 运行本脚本
-useQPython3: "false"
+# 是否使用 QPython3.6 运行本脚本
+useQPython3: "true"

--- a/config.yaml
+++ b/config.yaml
@@ -40,3 +40,6 @@ DebugLevel: "info"
 
 #使用ios短信和mac电脑接收验证码
 useIMessage: "false"
+
+# 是否使用 QPython3 运行本脚本
+useQPython3: "false"

--- a/qpython3.py
+++ b/qpython3.py
@@ -1,6 +1,7 @@
 import re
 import datetime
 import logging
+import time
 
 from androidhelper import Android
 
@@ -13,7 +14,6 @@ class QPython3(object):
         # Android QPython3
         self.droid = Android()
         logging.debug("QPython3 实例初始化完成")
-
     # 读取验证码短信
     def _get_sms_verify_code(self):
         # init
@@ -21,47 +21,59 @@ class QPython3(object):
         code = '000000'
         retry = 600
         # loop
+        logging.debug("监控短信中……")
         while retry > 0:
             retry -= 1
             # 检查 SMS
             code = self._check_sms_verify_code()
             # 有效验证码？
             if code != '000000':
+                logging.debug("取得有效验证码……"+code)
                 break
             else:
+                logging.debug("未找到有效验证码……重试中, retry = {}".format(retry))
                 time.sleep(0.05)
+        else:
+            logging.debug("未找到有效验证码……"+code)
         return code
-
     # 读取验证码短信
     def _check_sms_verify_code(self):
         # init
         code = '000000'
         # 获取当前的全部未读短信
         smsMessageIds = self.droid.smsGetMessageIds(True)
+        # 无短信退出
+        if len(smsMessageIds.result) == 0:
+            logging.debug("无短信退出……")
+            return code
         # loop
-        for smsId in smsMessageIds:
+        for smsId in smsMessageIds.result:
             # get message
             smsMessage = self.droid.smsGetMessageById(smsId)
-            # TODO 时间筛选
-            smsTimestamp = smsMessage.timestamp
+            # 时间筛选
+            smsTimestamp = datetime.datetime.fromtimestamp(int(smsMessage.result['date'])/1e3)
             # 跳过开始时间点前 SMS
             if smsTimestamp < self.start_time:
+                # print("时间跳过:", smsMessage)
                 continue
-            # TODO 文字匹配
-            smsContent = smsMessage.content
+            # 文字匹配
+            smsContent = smsMessage.result['body']
             res = self.regex.search(smsContent)
             if res is None:
+                # print("匹配跳过:", smsMessage)
                 continue
             else:
+                # print("发现短信:", smsMessage)
                 code = res.group(1).strip()
                 break
         return code
-
     # 获取验证码的外部调用
     def get_verify_code(self):
         logging.debug("获取验证码中……")
         # 读取验证码短信
         return self._get_sms_verify_code()
+
+
 
 ## 测试使用
 def main():

--- a/qpython3.py
+++ b/qpython3.py
@@ -1,0 +1,76 @@
+import re
+import datetime
+import logging
+
+from androidhelper import Android
+
+# 主 Class
+class QPython3(object):
+    # 初始化
+    def __init__(self):
+        self.regex = re.compile('证码为.*【(\d+)】') # regex
+        self.start_time = datetime.datetime.now()
+        # Android QPython3
+        self.droid = Android()
+        logging.debug("QPython3 实例初始化完成")
+
+    # 读取验证码短信
+    def _get_sms_verify_code(self):
+        # init
+        self.start_time = datetime.datetime.now()
+        code = '000000'
+        retry = 600
+        # loop
+        while retry > 0:
+            retry -= 1
+            # 检查 SMS
+            code = self._check_sms_verify_code()
+            # 有效验证码？
+            if code != '000000':
+                break
+            else:
+                time.sleep(0.05)
+        return code
+
+    # 读取验证码短信
+    def _check_sms_verify_code(self):
+        # init
+        code = '000000'
+        # 获取当前的全部未读短信
+        smsMessageIds = self.droid.smsGetMessageIds(True)
+        # loop
+        for smsId in smsMessageIds:
+            # get message
+            smsMessage = self.droid.smsGetMessageById(smsId)
+            # TODO 时间筛选
+            smsTimestamp = smsMessage.timestamp
+            # 跳过开始时间点前 SMS
+            if smsTimestamp < self.start_time:
+                continue
+            # TODO 文字匹配
+            smsContent = smsMessage.content
+            res = self.regex.search(smsContent)
+            if res is None:
+                continue
+            else:
+                code = res.group(1).strip()
+                break
+        return code
+
+    # 获取验证码的外部调用
+    def get_verify_code(self):
+        logging.debug("获取验证码中……")
+        # 读取验证码短信
+        return self._get_sms_verify_code()
+
+## 测试使用
+def main():
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(filename)s[line:%(lineno)d] %(levelname)s %(message)s',
+                        datefmt='%a, %d %b %Y %H:%M:%S')
+    droid = QPython3()
+    code = droid.get_verify_code()
+    print(code)
+
+if __name__ == '__main__':
+    main()

--- a/qpython3_run.py
+++ b/qpython3_run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -
+
+# 这里需修改 config_name 为你的配置文件名称，如
+config_name = "config.yaml"
+
+# 以脚本地址作为配置文件地址
+import sys, os
+config_path = os.path.join(os.path.dirname(sys.argv[0]), config_name)
+
+try:
+    import requests
+except:
+    import pip
+    pip.main(['install', 'requests'])
+
+try:
+    import yaml
+except:
+    import pip
+    pip.main(['install', 'PyYAML'])
+
+if __name__ == "__main__":
+    from bjguahao import Guahao
+    guahao = Guahao(config_path)
+    guahao.run()


### PR DESCRIPTION
- 主脚本兼容 Android QPython3 + QPy3.6
- 增加了 QPython3 启动脚本
- 增加了 QPython3 短信监视脚本
- 增加了 config 文件的容错功能，useIMessage 和 useQPython3 默认为 false
- 在非 Android 平台运行时，增加 useQPython3 = true 的容错功能
- imessage.py 仅在 useIMessage = true 时载入
- update .gitignore to exclude all yaml except config.yaml
- cookies 文件将强制储存在项目目录下

已测试：
- PC 仍可正常运行
- Android 端放号后成功挂号

未测试：
- macOS 情况未知
- Android 端放号前监测挂号

请暂时不要合并。
