### PR TITLE
Bump PyYAML to 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.18.3
-PyYAML==3.12
+PyYAML==3.13


### PR DESCRIPTION
PyYAML 3.12 has issues when using Python version 3.7 on macOS. So we can bump to 3.13 to fix these issues.


```
    /usr/local/include/yaml.h:604:43: note: passing argument to parameter 'tag' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                                              ^
    ext/_yaml.c:17037:70: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        __pyx_t_2 = ((yaml_mapping_start_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                         ^~~~~~~~~~~~~~
    /usr/local/include/yaml.h:636:22: note: passing argument to parameter 'anchor' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                         ^
    ext/_yaml.c:17037:86: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        __pyx_t_2 = ((yaml_mapping_start_event_initialize(__pyx_v_event, __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                                         ^~~~~~~~~~~
    /usr/local/include/yaml.h:636:43: note: passing argument to parameter 'tag' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                                              ^
    ext/_yaml.c:18516:42: warning: assigning to 'yaml_char_t *' (aka 'unsigned char *') from 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_v_tag_directives_end->handle = PyString_AS_STRING(__pyx_v_handle);
                                             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:18631:42: warning: assigning to 'yaml_char_t *' (aka 'unsigned char *') from 'char *' converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_v_tag_directives_end->prefix = PyString_AS_STRING(__pyx_v_prefix);
                                             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ext/_yaml.c:19491:65: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
        __pyx_t_2 = ((yaml_alias_event_initialize((&__pyx_v_event), __pyx_v_anchor) == 0) != 0);
                                                                    ^~~~~~~~~~~~~~
    /usr/local/include/yaml.h:555:63: note: passing argument to parameter 'anchor' here
    yaml_alias_event_initialize(yaml_event_t *event, yaml_char_t *anchor);
                                                                  ^
    ext/_yaml.c:20240:68: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_scalar_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                       ^~~~~~~~~~~~~~
    /usr/local/include/yaml.h:581:22: note: passing argument to parameter 'anchor' here
            yaml_char_t *anchor, yaml_char_t *tag,
                         ^
    ext/_yaml.c:20240:84: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_scalar_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                                       ^~~~~~~~~~~
    /usr/local/include/yaml.h:581:43: note: passing argument to parameter 'tag' here
            yaml_char_t *anchor, yaml_char_t *tag,
                                              ^
    ext/_yaml.c:20240:97: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_scalar_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_value, __pyx_v_length, __pyx_v_plain_implicit, __pyx_v_quoted_implicit, __pyx_v_scalar_style) == 0) != 0);
                                                                                                    ^~~~~~~~~~~~~
    /usr/local/include/yaml.h:582:22: note: passing argument to parameter 'value' here
            yaml_char_t *value, int length,
                         ^
    ext/_yaml.c:20605:76: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_sequence_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_sequence_style) == 0) != 0);
                                                                               ^~~~~~~~~~~~~~
    /usr/local/include/yaml.h:604:22: note: passing argument to parameter 'anchor' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                         ^
    ext/_yaml.c:20605:92: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_sequence_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_sequence_style) == 0) != 0);
                                                                                               ^~~~~~~~~~~
    /usr/local/include/yaml.h:604:43: note: passing argument to parameter 'tag' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                                              ^
    ext/_yaml.c:21113:75: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_mapping_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                              ^~~~~~~~~~~~~~
    /usr/local/include/yaml.h:636:22: note: passing argument to parameter 'anchor' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                         ^
    ext/_yaml.c:21113:91: warning: passing 'char *' to parameter of type 'yaml_char_t *' (aka 'unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
          __pyx_t_2 = ((yaml_mapping_start_event_initialize((&__pyx_v_event), __pyx_v_anchor, __pyx_v_tag, __pyx_v_implicit, __pyx_v_mapping_style) == 0) != 0);
                                                                                              ^~~~~~~~~~~
    /usr/local/include/yaml.h:636:43: note: passing argument to parameter 'tag' here
            yaml_char_t *anchor, yaml_char_t *tag, int implicit,
                                              ^
    ext/_yaml.c:24143:21: error: no member named 'exc_type' in 'struct _ts'
        *type = tstate->exc_type;
                ~~~~~~  ^
    ext/_yaml.c:24144:22: error: no member named 'exc_value' in 'struct _ts'; did you mean 'curexc_value'?
        *value = tstate->exc_value;
                         ^~~~~~~~~
                         curexc_value
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:237:15: note: 'curexc_value' declared here
        PyObject *curexc_value;
                  ^
    ext/_yaml.c:24145:19: error: no member named 'exc_traceback' in 'struct _ts'; did you mean 'curexc_traceback'?
        *tb = tstate->exc_traceback;
                      ^~~~~~~~~~~~~
                      curexc_traceback
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:238:15: note: 'curexc_traceback' declared here
        PyObject *curexc_traceback;
                  ^
    ext/_yaml.c:24152:24: error: no member named 'exc_type' in 'struct _ts'
        tmp_type = tstate->exc_type;
                   ~~~~~~  ^
    ext/_yaml.c:24153:25: error: no member named 'exc_value' in 'struct _ts'; did you mean 'curexc_value'?
        tmp_value = tstate->exc_value;
                            ^~~~~~~~~
                            curexc_value
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:237:15: note: 'curexc_value' declared here
        PyObject *curexc_value;
                  ^
    ext/_yaml.c:24154:22: error: no member named 'exc_traceback' in 'struct _ts'; did you mean 'curexc_traceback'?
        tmp_tb = tstate->exc_traceback;
                         ^~~~~~~~~~~~~
                         curexc_traceback
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:238:15: note: 'curexc_traceback' declared here
        PyObject *curexc_traceback;
                  ^
    ext/_yaml.c:24155:13: error: no member named 'exc_type' in 'struct _ts'
        tstate->exc_type = type;
        ~~~~~~  ^
    ext/_yaml.c:24156:13: error: no member named 'exc_value' in 'struct _ts'; did you mean 'curexc_value'?
        tstate->exc_value = value;
                ^~~~~~~~~
                curexc_value
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:237:15: note: 'curexc_value' declared here
        PyObject *curexc_value;
                  ^
    ext/_yaml.c:24157:13: error: no member named 'exc_traceback' in 'struct _ts'; did you mean 'curexc_traceback'?
        tstate->exc_traceback = tb;
                ^~~~~~~~~~~~~
                curexc_traceback
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:238:15: note: 'curexc_traceback' declared here
        PyObject *curexc_traceback;
                  ^
    ext/_yaml.c:24212:24: error: no member named 'exc_type' in 'struct _ts'
        tmp_type = tstate->exc_type;
                   ~~~~~~  ^
    ext/_yaml.c:24213:25: error: no member named 'exc_value' in 'struct _ts'; did you mean 'curexc_value'?
        tmp_value = tstate->exc_value;
                            ^~~~~~~~~
                            curexc_value
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:237:15: note: 'curexc_value' declared here
        PyObject *curexc_value;
                  ^
    ext/_yaml.c:24214:22: error: no member named 'exc_traceback' in 'struct _ts'; did you mean 'curexc_traceback'?
        tmp_tb = tstate->exc_traceback;
                         ^~~~~~~~~~~~~
                         curexc_traceback
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:238:15: note: 'curexc_traceback' declared here
        PyObject *curexc_traceback;
                  ^
    ext/_yaml.c:24215:13: error: no member named 'exc_type' in 'struct _ts'
        tstate->exc_type = local_type;
        ~~~~~~  ^
    ext/_yaml.c:24216:13: error: no member named 'exc_value' in 'struct _ts'; did you mean 'curexc_value'?
        tstate->exc_value = local_value;
                ^~~~~~~~~
                curexc_value
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:237:15: note: 'curexc_value' declared here
        PyObject *curexc_value;
                  ^
    ext/_yaml.c:24217:13: error: no member named 'exc_traceback' in 'struct _ts'; did you mean 'curexc_traceback'?
        tstate->exc_traceback = local_tb;
                ^~~~~~~~~~~~~
                curexc_traceback
    /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pystate.h:238:15: note: 'curexc_traceback' declared here
        PyObject *curexc_traceback;
                  ^
    51 warnings and 15 errors generated.
    error: command 'clang' failed with exit status 1

    ----------------------------------------
```